### PR TITLE
Fix #559 - Update Node.js to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   tag:
     description: 'tag name'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: "git-merge"


### PR DESCRIPTION
This pull request should fix #559, and silence the Node.js v16 deprecation warnings.

I have [tested this change on another repo that uses my forked version here][1]

[1]: https://github.com/LyraPhase/sprout-wrap/actions/runs/10262736236/job/28393043750#step:7:1